### PR TITLE
[task 85895] improving filters in metadata export search

### DIFF
--- a/dspace-api/metadataExportSearch.csv
+++ b/dspace-api/metadataExportSearch.csv
@@ -1,3 +1,0 @@
-id,collection,dc.date.accessioned,dc.date.available,dc.description.provenance[en],dc.identifier.uri,dc.subject[*],dc.title[*]
-"7200684b-555e-41f6-8b8f-ffe55f6ed164","123456789/58","2021-11-19T15:55:36Z","2021-11-19T15:55:36Z","Made available in DSpace on 2021-11-19T15:55:36Z (GMT). No. of bitstreams: 0","http://localhost:4000/handle/123456789/89","subject2","subject2 item 0"
-"55d55ecf-4dd3-4a5e-b8f6-9d8214b76b03","123456789/58","2021-11-19T15:55:36Z","2021-11-19T15:55:36Z","Made available in DSpace on 2021-11-19T15:55:36Z (GMT). No. of bitstreams: 0","http://localhost:4000/handle/123456789/90","subject2","subject2 item 1"


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
