### PR TITLE
W2p 85895 export metadata from search results feedback

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
@@ -107,7 +107,7 @@ public class MetadataExportSearch extends DSpaceRunnable<MetadataExportSearchScr
             discoveryConfigurationService.getDiscoveryConfiguration(discoveryConfigName);
 
         if (filterQueryStrings != null) {
-            for(String filterQueryString: filterQueryStrings) {
+            for (String filterQueryString: filterQueryStrings) {
                 String field = filterQueryString.split(",", 2)[0];
                 String operator = filterQueryString.split("('|=)", 3)[1];
                 String value = filterQueryString.split("=", 2)[1];

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
@@ -107,11 +107,14 @@ public class MetadataExportSearch extends DSpaceRunnable<MetadataExportSearchScr
             discoveryConfigurationService.getDiscoveryConfiguration(discoveryConfigName);
 
         if (filterQueryString != null) {
+            String field = filterQueryString.split(",", 2)[0];
+            String operator = filterQueryString.split("('|=)", 3)[1];
+            String value = filterQueryString.split("=", 2)[1];
             DiscoverFilterQuery filterQuery = searchService.toFilterQuery(
                 context,
-                filterQueryString.split(",", 2)[0],
-                filterQueryString.split("('|=)", 3)[1],
-                filterQueryString.split("=", 2)[1],
+                field,
+                operator,
+                value,
                 discoveryConfiguration);
             discoverQuery.addFilterQueries(filterQuery.getFilterQuery());
         }

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
@@ -39,7 +39,7 @@ public class MetadataExportSearch extends DSpaceRunnable<MetadataExportSearchScr
     private String identifier;
     private String discoveryConfigName;
     private String advancedFilter;
-    private String filterQueryString;
+    private String[] filterQueryStrings;
     private boolean exportAllItems = true;
 
     private SearchService searchService =
@@ -81,7 +81,7 @@ public class MetadataExportSearch extends DSpaceRunnable<MetadataExportSearchScr
         }
 
         if (commandLine.hasOption('f')) {
-            filterQueryString = commandLine.getOptionValue('f');
+            filterQueryStrings = commandLine.getOptionValues('f');
         }
     }
 
@@ -106,17 +106,19 @@ public class MetadataExportSearch extends DSpaceRunnable<MetadataExportSearchScr
         DiscoveryConfiguration discoveryConfiguration =
             discoveryConfigurationService.getDiscoveryConfiguration(discoveryConfigName);
 
-        if (filterQueryString != null) {
-            String field = filterQueryString.split(",", 2)[0];
-            String operator = filterQueryString.split("('|=)", 3)[1];
-            String value = filterQueryString.split("=", 2)[1];
-            DiscoverFilterQuery filterQuery = searchService.toFilterQuery(
-                context,
-                field,
-                operator,
-                value,
-                discoveryConfiguration);
-            discoverQuery.addFilterQueries(filterQuery.getFilterQuery());
+        if (filterQueryStrings != null) {
+            for(String filterQueryString: filterQueryStrings) {
+                String field = filterQueryString.split(",", 2)[0];
+                String operator = filterQueryString.split("('|=)", 3)[1];
+                String value = filterQueryString.split("=", 2)[1];
+                DiscoverFilterQuery filterQuery = searchService.toFilterQuery(
+                    context,
+                    field,
+                    operator,
+                    value,
+                    discoveryConfiguration);
+                discoverQuery.addFilterQueries(filterQuery.getFilterQuery());
+            }
         }
         Iterator<Item> itemIterator = searchService.iteratorSearch(context, dso, discoverQuery);
         DSpaceCSV dSpaceCSV = metadataDSpaceCsvExportService.export(context, itemIterator, true);

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.io.Files;
@@ -153,5 +154,15 @@ public class MetadataExportSearchIT extends AbstractIntegrationTestWithDatabase 
         String[] args = new String[] {"metadata-export-search", "-f", "dateIssued,equals=[2000 TO 2020]"};
         ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
         checkItemsPresentInFile(filename, itemsSubject1);
+    }
+
+    @Test
+    public void exportMetadataSearchMultipleFilters()
+        throws InstantiationException, IllegalAccessException, IOException, CsvException {
+        String[] args = new String[] {"metadata-export-search", "-f", "subject,equals=" + subject1, "-f",
+            "title,equals=" + String.format("%s item %d", subject1, 0)};
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+        Item[] expectedResult = Arrays.copyOfRange(itemsSubject1, 0, 1);
+        checkItemsPresentInFile(filename, expectedResult);
     }
 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
